### PR TITLE
chore(review-code): bump version to 2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,15 @@ jobs:
       - name: Publish to PRPM
         env:
           SKILL_DIR: ${{ steps.tag.outputs.skill_dir }}
-        run: cd "$SKILL_DIR" && prpm publish
+        run: |
+          cd "$SKILL_DIR"
+          output=$(prpm publish 2>&1) && exit 0
+          if echo "$output" | grep -q "Version already exists"; then
+            echo "Version already published — skipping (idempotent)"
+          else
+            echo "$output" >&2
+            exit 1
+          fi
 
       - name: Create GitHub Release
         uses: dakaneye/hookshot/release-pilot@v1

--- a/skills/review-code/prpm.json
+++ b/skills/review-code/prpm.json
@@ -1,6 +1,6 @@
 {
   "name": "dakaneye-review-code",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Comprehensive code review skill with language-specific expertise, 14-dimension scorecard, AI-spray detection, and staff-level analysis. Supports Go (DRIVEC), Node.js (STREAMS), Java (INVEST), Python (TYPED), Bash (VEST), Rust (BORROWS), and Terraform (STATELOCK).",
   "author": "dakaneye",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump review-code version to 2.1.0 after publishing to PRPM
- Make PRPM publish step idempotent (tolerate "Version already exists" on reruns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)